### PR TITLE
Unidades de 0

### DIFF
--- a/imports/ui/App.css
+++ b/imports/ui/App.css
@@ -17,9 +17,10 @@
 .navigationBar {
   position: fixed;
   width: 100%;
-  top: 0px;
-  left: 0px;
-  right: 0px;
+  // no es necesario colocar unidades al 0
+  top: 0;
+  left: 0;
+  right: 0;
   clear: both;
   z-index: 1000;
 }
@@ -31,6 +32,6 @@
 
 .menu {
   position: fixed;
-  left : 0px;
+  left : 0;
   top : 50px;
 }


### PR DESCRIPTION
Colocar unidades cuando el valor es 0 es algo redundante por lo que no es necesario.